### PR TITLE
changed boot Job pod DNS server to 8.8.8.8

### DIFF
--- a/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/.lighthouse/jenkins-x/pullrequest.yaml
@@ -28,7 +28,14 @@ spec:
             requests:
               cpu: 0.1
               memory: 128Mi
-  podTemplate: {}
+  podTemplate:
+    dnsPolicy: "None"
+    dnsConfig:
+      nameservers:
+        - 8.8.8.8
+      options:
+        - name: ndots
+          value: "1"
   serviceAccountName: tekton-bot
   timeout: 12h0m0s
 status: {}

--- a/.lighthouse/jenkins-x/release.yaml
+++ b/.lighthouse/jenkins-x/release.yaml
@@ -29,7 +29,14 @@ spec:
             requests:
               cpu: 0.1
               memory: 128Mi
-  podTemplate: {}
+  podTemplate:
+    dnsPolicy: "None"
+    dnsConfig:
+      nameservers:
+        - 8.8.8.8
+      options:
+        - name: ndots
+          value: "1"
   serviceAccountName: tekton-bot
   timeout: 12h0m0s
 status: {}

--- a/versionStream/git-operator/job.yaml
+++ b/versionStream/git-operator/job.yaml
@@ -53,7 +53,13 @@ spec:
             - mountPath: /workspace
               name: workspace-volume
           workingDir: /workspace/source
-      dnsPolicy: ClusterFirst
+      dnsPolicy: "None"
+      dnsConfig:
+        nameservers:
+          - 8.8.8.8
+        options:
+          - name: ndots
+            value: "1"
       restartPolicy: Never
       schedulerName: default-scheduler
       serviceAccountName: jx-boot-job


### PR DESCRIPTION
changed boot Job pod DNS server to 8.8.8.8 since alpine v3.13 and above gives DNS resolution error.
During cloning cluster git repository inside pod, it throws error stating "cannot able to resolve github.com"